### PR TITLE
Graphql

### DIFF
--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -1,5 +1,11 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
+import { graphql, GraphQLSchema } from 'graphql';
+import { queryType } from './query';
 import { graphqlBodySchema } from './schema';
+
+const MyAppSchema = new GraphQLSchema({
+  query: queryType,
+});
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
@@ -11,7 +17,14 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: graphqlBodySchema,
       },
     },
-    async function (request, reply) {}
+    async function (request, reply) {
+      return await graphql({
+        schema: MyAppSchema,
+        source: request.body.query?.toString() || '',
+        contextValue: fastify,
+        variableValues: request.body.variables,
+      });
+    }
   );
 };
 

--- a/src/routes/graphql/query.ts
+++ b/src/routes/graphql/query.ts
@@ -1,0 +1,22 @@
+import { FastifyInstance } from 'fastify';
+import { GraphQLList, GraphQLObjectType } from 'graphql';
+import { userDataType } from './types';
+
+const usersQuery = {
+  type: new GraphQLList(userDataType),
+  resolve: async (_: any, __: any, fastify: FastifyInstance) => {
+    const users = await fastify.db.users.findMany();
+    if (users) {
+      return users
+    } else {
+      throw fastify.httpErrors.notFound()
+    };
+  },
+};
+
+export const queryType = new GraphQLObjectType({
+  name: 'Query',
+  fields: {
+    users: usersQuery,
+  },
+});

--- a/src/routes/graphql/types.ts
+++ b/src/routes/graphql/types.ts
@@ -1,0 +1,102 @@
+import {
+  GraphQLID,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql';
+
+const userTypeBasic = {
+  id: { type: GraphQLID },
+  firstName: { type: GraphQLString },
+  lastName: { type: GraphQLString },
+  email: { type: GraphQLString },
+  subscribedToUserIds: { type: new GraphQLList(GraphQLID) },
+};
+
+// const userType = new GraphQLObjectType({
+//   name: 'User',
+//   fields: userTypeBasic,
+// });
+
+const profileTypeBasic = {
+  id: { type: GraphQLID },
+  avatar: { type: GraphQLString },
+  sex: { type: GraphQLString },
+  birthday: { type: GraphQLInt },
+  country: { type: GraphQLString },
+  street: { type: GraphQLString },
+  city: { type: GraphQLString },
+  memberTypeId: { type: GraphQLString },
+  userId: { type: GraphQLID },
+};
+
+const profileType = new GraphQLObjectType({
+  name: 'Profile',
+  fields: profileTypeBasic,
+});
+
+const postTypeBasic = {
+  id: { type: GraphQLID },
+  title: { type: GraphQLString },
+  content: { type: GraphQLString },
+  userId: { type: GraphQLID },
+};
+
+const postType = new GraphQLObjectType({
+  name: 'Post',
+  fields: postTypeBasic,
+});
+
+const memberTypeTypeBasic = {
+  id: { type: GraphQLString },
+  discount: { type: GraphQLInt },
+  monthPostsLimit: { type: GraphQLInt },
+};
+
+const memberTypeType = new GraphQLObjectType({
+  name: 'MemberType',
+  fields: memberTypeTypeBasic,
+});
+
+export const userDataType = new GraphQLObjectType({
+  name: 'User',
+  fields: {
+    ...userTypeBasic,
+    profile: {
+      type: profileType,
+      resolve: async (parent, _, fastify) => {
+        const profile = await fastify.db.profiles.findOne({ key: 'id', equals: parent.id });
+        if (profile) {
+          return profile;
+        } else {
+          throw fastify.httpErrors.notFound();
+        };
+      },
+    },
+    posts: {
+      type: new GraphQLList(postType),
+      resolve: async (parent, _, fastify) => {
+        const posts = await fastify.db.posts.findMany({ key: 'id', equals: parent.id });
+  
+        if (!posts.length) {
+          throw fastify.httpErrors.notFound();
+        } else {
+          return posts;
+        };
+      },
+    },
+    memberType: {
+      type: memberTypeType,
+      resolve: async (parent, _, fastify) => {
+        const memberType = await fastify.db.memberTypes.findOne({ key: 'id', equals: parent.profile.id });
+  
+        if (memberType) {
+          return memberType;
+        } else {
+          throw fastify.httpErrors.notFound();
+        };
+      },
+    },
+  },
+});

--- a/src/routes/member-types/index.ts
+++ b/src/routes/member-types/index.ts
@@ -1,35 +1,35 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
-import { idParamSchema } from '../../utils/reusedSchemas';
-import { changeMemberTypeBodySchema } from './schema';
-import type { MemberTypeEntity } from '../../utils/DB/entities/DBMemberTypes';
+// import { idParamSchema } from '../../utils/reusedSchemas';
+// import { changeMemberTypeBodySchema } from './schema';
+// import type { MemberTypeEntity } from '../../utils/DB/entities/DBMemberTypes';
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<
-    MemberTypeEntity[]
-  > {});
+  // fastify.get('/', async function (request, reply): Promise<
+  //   MemberTypeEntity[]
+  // > {});
 
-  fastify.get(
-    '/:id',
-    {
-      schema: {
-        params: idParamSchema,
-      },
-    },
-    async function (request, reply): Promise<MemberTypeEntity> {}
-  );
+  // fastify.get(
+  //   '/:id',
+  //   {
+  //     schema: {
+  //       params: idParamSchema,
+  //     },
+  //   },
+  //   async function (request, reply): Promise<MemberTypeEntity> {}
+  // );
 
-  fastify.patch(
-    '/:id',
-    {
-      schema: {
-        body: changeMemberTypeBodySchema,
-        params: idParamSchema,
-      },
-    },
-    async function (request, reply): Promise<MemberTypeEntity> {}
-  );
+  // fastify.patch(
+  //   '/:id',
+  //   {
+  //     schema: {
+  //       body: changeMemberTypeBodySchema,
+  //       params: idParamSchema,
+  //     },
+  //   },
+  //   async function (request, reply): Promise<MemberTypeEntity> {}
+  // );
 };
 
 export default plugin;

--- a/src/routes/member-types/index.ts
+++ b/src/routes/member-types/index.ts
@@ -1,35 +1,58 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
-// import { idParamSchema } from '../../utils/reusedSchemas';
-// import { changeMemberTypeBodySchema } from './schema';
-// import type { MemberTypeEntity } from '../../utils/DB/entities/DBMemberTypes';
+import { idParamSchema } from '../../utils/reusedSchemas';
+import { changeMemberTypeBodySchema } from './schema';
+import type { MemberTypeEntity } from '../../utils/DB/entities/DBMemberTypes';
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  // fastify.get('/', async function (request, reply): Promise<
-  //   MemberTypeEntity[]
-  // > {});
+  fastify.get('/', async function (request, reply): Promise<MemberTypeEntity[]> {
+    const memberTypes = await fastify.db.memberTypes.findMany();
+    if (memberTypes) {
+      return memberTypes
+    } else {
+      throw fastify.httpErrors.notFound()
+    };
+  });
 
-  // fastify.get(
-  //   '/:id',
-  //   {
-  //     schema: {
-  //       params: idParamSchema,
-  //     },
-  //   },
-  //   async function (request, reply): Promise<MemberTypeEntity> {}
-  // );
+  fastify.get(
+    '/:id',
+    {
+      schema: {
+        params: idParamSchema,
+      },
+    },
+    async function (request, reply): Promise<MemberTypeEntity> {
+      const id = request.params.id;
+      const memberType = await fastify.db.memberTypes.findOne({ key: 'id', equals: id });
 
-  // fastify.patch(
-  //   '/:id',
-  //   {
-  //     schema: {
-  //       body: changeMemberTypeBodySchema,
-  //       params: idParamSchema,
-  //     },
-  //   },
-  //   async function (request, reply): Promise<MemberTypeEntity> {}
-  // );
+      if (memberType) {
+        return memberType;
+      } else {
+        throw fastify.httpErrors.notFound();
+      };
+    }
+  );
+
+  fastify.patch(
+    '/:id',
+    {
+      schema: {
+        body: changeMemberTypeBodySchema,
+        params: idParamSchema,
+      },
+    },
+    async function (request, reply): Promise<MemberTypeEntity> {
+      const id = request.params.id;
+      const newMemberType = request.body; 
+      const memberType = await fastify.db.memberTypes.findOne({ key: 'id', equals: id });
+      if (memberType) {
+        return await fastify.db.memberTypes.change(id, newMemberType);
+      } else {
+        throw fastify.httpErrors.badRequest();
+      };
+    }
+  );
 };
 
 export default plugin;

--- a/src/routes/posts/index.ts
+++ b/src/routes/posts/index.ts
@@ -1,53 +1,53 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
-import { idParamSchema } from '../../utils/reusedSchemas';
-import { createPostBodySchema, changePostBodySchema } from './schema';
-import type { PostEntity } from '../../utils/DB/entities/DBPosts';
+// import { idParamSchema } from '../../utils/reusedSchemas';
+// import { createPostBodySchema, changePostBodySchema } from './schema';
+// import type { PostEntity } from '../../utils/DB/entities/DBPosts';
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<PostEntity[]> {});
+  // fastify.get('/', async function (request, reply): Promise<PostEntity[]> {});
 
-  fastify.get(
-    '/:id',
-    {
-      schema: {
-        params: idParamSchema,
-      },
-    },
-    async function (request, reply): Promise<PostEntity> {}
-  );
+  // fastify.get(
+  //   '/:id',
+  //   {
+  //     schema: {
+  //       params: idParamSchema,
+  //     },
+  //   },
+  //   async function (request, reply): Promise<PostEntity> {}
+  // );
 
-  fastify.post(
-    '/',
-    {
-      schema: {
-        body: createPostBodySchema,
-      },
-    },
-    async function (request, reply): Promise<PostEntity> {}
-  );
+  // fastify.post(
+  //   '/',
+  //   {
+  //     schema: {
+  //       body: createPostBodySchema,
+  //     },
+  //   },
+  //   async function (request, reply): Promise<PostEntity> {}
+  // );
 
-  fastify.delete(
-    '/:id',
-    {
-      schema: {
-        params: idParamSchema,
-      },
-    },
-    async function (request, reply): Promise<PostEntity> {}
-  );
+  // fastify.delete(
+  //   '/:id',
+  //   {
+  //     schema: {
+  //       params: idParamSchema,
+  //     },
+  //   },
+  //   async function (request, reply): Promise<PostEntity> {}
+  // );
 
-  fastify.patch(
-    '/:id',
-    {
-      schema: {
-        body: changePostBodySchema,
-        params: idParamSchema,
-      },
-    },
-    async function (request, reply): Promise<PostEntity> {}
-  );
+  // fastify.patch(
+  //   '/:id',
+  //   {
+  //     schema: {
+  //       body: changePostBodySchema,
+  //       params: idParamSchema,
+  //     },
+  //   },
+  //   async function (request, reply): Promise<PostEntity> {}
+  // );
 };
 
 export default plugin;

--- a/src/routes/posts/index.ts
+++ b/src/routes/posts/index.ts
@@ -1,53 +1,93 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
-// import { idParamSchema } from '../../utils/reusedSchemas';
-// import { createPostBodySchema, changePostBodySchema } from './schema';
-// import type { PostEntity } from '../../utils/DB/entities/DBPosts';
+import { idParamSchema } from '../../utils/reusedSchemas';
+import { createPostBodySchema, changePostBodySchema } from './schema';
+import type { PostEntity } from '../../utils/DB/entities/DBPosts';
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  // fastify.get('/', async function (request, reply): Promise<PostEntity[]> {});
+  fastify.get('/', async function (request, reply): Promise<PostEntity[]> {
+    const posts = await fastify.db.posts.findMany();
+    if (posts) {
+      return posts
+    } else {
+      throw fastify.httpErrors.notFound()
+    };
+  });
 
-  // fastify.get(
-  //   '/:id',
-  //   {
-  //     schema: {
-  //       params: idParamSchema,
-  //     },
-  //   },
-  //   async function (request, reply): Promise<PostEntity> {}
-  // );
+  fastify.get(
+    '/:id',
+    {
+      schema: {
+        params: idParamSchema,
+      },
+    },
+    async function (request, reply): Promise<PostEntity> {
+      const id = request.params.id;
+      const post = await fastify.db.posts.findOne({ key: 'id', equals: id });
 
-  // fastify.post(
-  //   '/',
-  //   {
-  //     schema: {
-  //       body: createPostBodySchema,
-  //     },
-  //   },
-  //   async function (request, reply): Promise<PostEntity> {}
-  // );
+      if (post) {
+        return post;
+      } else {
+        throw fastify.httpErrors.notFound();
+      };
+    }
+  );
 
-  // fastify.delete(
-  //   '/:id',
-  //   {
-  //     schema: {
-  //       params: idParamSchema,
-  //     },
-  //   },
-  //   async function (request, reply): Promise<PostEntity> {}
-  // );
+  fastify.post(
+    '/',
+    {
+      schema: {
+        body: createPostBodySchema,
+      },
+    },
+    async function (request, reply): Promise<PostEntity> {
+      const post = request.body;
+      if (post) {
+        return await fastify.db.posts.create(post);
+      } else {
+        throw fastify.httpErrors.badRequest();
+      };
+    }
+  );
 
-  // fastify.patch(
-  //   '/:id',
-  //   {
-  //     schema: {
-  //       body: changePostBodySchema,
-  //       params: idParamSchema,
-  //     },
-  //   },
-  //   async function (request, reply): Promise<PostEntity> {}
-  // );
+  fastify.delete(
+    '/:id',
+    {
+      schema: {
+        params: idParamSchema,
+      },
+    },
+    async function (request, reply): Promise<PostEntity> {
+      const id = request.params.id;
+      const post = await fastify.db.posts.findOne({ key: 'id', equals: id });
+      if (post) {
+        return await fastify.db.posts.delete(id);
+      } else {
+        throw fastify.httpErrors.badRequest();
+      };
+    }
+  );
+
+  fastify.patch(
+    '/:id',
+    {
+      schema: {
+        body: changePostBodySchema,
+        params: idParamSchema,
+      },
+    },
+    async function (request, reply): Promise<PostEntity> {
+      const id = request.params.id;
+      const newPost = request.body; 
+      const post = await fastify.db.posts.findOne({ key: 'id', equals: id });
+      if (post) {
+        return await fastify.db.posts.change(id, newPost);
+      } else {
+        throw fastify.httpErrors.badRequest();
+      };
+    }
+  );
 };
 
 export default plugin;

--- a/src/routes/profiles/index.ts
+++ b/src/routes/profiles/index.ts
@@ -42,15 +42,11 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
     },
     async function (request, reply): Promise<ProfileEntity> {
       const profile = request.body;
-      // const memberTypesId = await fastify.db.memberTypes.findOne({ key: 'id', equals: profile.memberTypeId });
       const userProfile = await fastify.db.profiles.findOne({ key: 'userId', equals: profile.userId });
       if (userProfile) {
         throw fastify.httpErrors.badRequest();
       }
-      // if (memberTypesId) {
-      //   throw fastify.httpErrors.badRequest();
-      // }
-      if (profile) {
+      if (profile && (profile.memberTypeId.includes('basic') || profile.memberTypeId.includes('business'))) {
         return await fastify.db.profiles.create(profile);
       } else {
         throw fastify.httpErrors.badRequest();

--- a/src/routes/profiles/index.ts
+++ b/src/routes/profiles/index.ts
@@ -1,55 +1,55 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
-import { idParamSchema } from '../../utils/reusedSchemas';
-import { createProfileBodySchema, changeProfileBodySchema } from './schema';
-import type { ProfileEntity } from '../../utils/DB/entities/DBProfiles';
+// import { idParamSchema } from '../../utils/reusedSchemas';
+// import { createProfileBodySchema, changeProfileBodySchema } from './schema';
+// import type { ProfileEntity } from '../../utils/DB/entities/DBProfiles';
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<
-    ProfileEntity[]
-  > {});
+//   fastify.get('/', async function (request, reply): Promise<
+//     ProfileEntity[]
+//   > {});
 
-  fastify.get(
-    '/:id',
-    {
-      schema: {
-        params: idParamSchema,
-      },
-    },
-    async function (request, reply): Promise<ProfileEntity> {}
-  );
+//   fastify.get(
+//     '/:id',
+//     {
+//       schema: {
+//         params: idParamSchema,
+//       },
+//     },
+//     async function (request, reply): Promise<ProfileEntity> {}
+//   );
 
-  fastify.post(
-    '/',
-    {
-      schema: {
-        body: createProfileBodySchema,
-      },
-    },
-    async function (request, reply): Promise<ProfileEntity> {}
-  );
+//   fastify.post(
+//     '/',
+//     {
+//       schema: {
+//         body: createProfileBodySchema,
+//       },
+//     },
+//     async function (request, reply): Promise<ProfileEntity> {}
+//   );
 
-  fastify.delete(
-    '/:id',
-    {
-      schema: {
-        params: idParamSchema,
-      },
-    },
-    async function (request, reply): Promise<ProfileEntity> {}
-  );
+//   fastify.delete(
+//     '/:id',
+//     {
+//       schema: {
+//         params: idParamSchema,
+//       },
+//     },
+//     async function (request, reply): Promise<ProfileEntity> {}
+//   );
 
-  fastify.patch(
-    '/:id',
-    {
-      schema: {
-        body: changeProfileBodySchema,
-        params: idParamSchema,
-      },
-    },
-    async function (request, reply): Promise<ProfileEntity> {}
-  );
+//   fastify.patch(
+//     '/:id',
+//     {
+//       schema: {
+//         body: changeProfileBodySchema,
+//         params: idParamSchema,
+//       },
+//     },
+//     async function (request, reply): Promise<ProfileEntity> {}
+//   );
 };
 
 export default plugin;

--- a/src/routes/profiles/index.ts
+++ b/src/routes/profiles/index.ts
@@ -1,55 +1,101 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
-// import { idParamSchema } from '../../utils/reusedSchemas';
-// import { createProfileBodySchema, changeProfileBodySchema } from './schema';
-// import type { ProfileEntity } from '../../utils/DB/entities/DBProfiles';
+import { idParamSchema } from '../../utils/reusedSchemas';
+import { createProfileBodySchema, changeProfileBodySchema } from './schema';
+import type { ProfileEntity } from '../../utils/DB/entities/DBProfiles';
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-//   fastify.get('/', async function (request, reply): Promise<
-//     ProfileEntity[]
-//   > {});
+  fastify.get('/', async function (request, reply): Promise<ProfileEntity[]> {
+    const profiles = await fastify.db.profiles.findMany();
+    if (profiles) {
+      return profiles
+    } else {
+      throw fastify.httpErrors.notFound()
+    };
+  });
 
-//   fastify.get(
-//     '/:id',
-//     {
-//       schema: {
-//         params: idParamSchema,
-//       },
-//     },
-//     async function (request, reply): Promise<ProfileEntity> {}
-//   );
+  fastify.get(
+    '/:id',
+    {
+      schema: {
+        params: idParamSchema,
+      },
+    },
+    async function (request, reply): Promise<ProfileEntity> {
+      const id = request.params.id;
+      const profile = await fastify.db.profiles.findOne({ key: 'id', equals: id });
+      if (profile) {
+        return profile;
+      } else {
+        throw fastify.httpErrors.notFound();
+      };
+    }
+  );
 
-//   fastify.post(
-//     '/',
-//     {
-//       schema: {
-//         body: createProfileBodySchema,
-//       },
-//     },
-//     async function (request, reply): Promise<ProfileEntity> {}
-//   );
+  fastify.post(
+    '/',
+    {
+      schema: {
+        body: createProfileBodySchema,
+      },
+    },
+    async function (request, reply): Promise<ProfileEntity> {
+      const profile = request.body;
+      // const memberTypesId = await fastify.db.memberTypes.findOne({ key: 'id', equals: profile.memberTypeId });
+      const userProfile = await fastify.db.profiles.findOne({ key: 'userId', equals: profile.userId });
+      if (userProfile) {
+        throw fastify.httpErrors.badRequest();
+      }
+      // if (memberTypesId) {
+      //   throw fastify.httpErrors.badRequest();
+      // }
+      if (profile) {
+        return await fastify.db.profiles.create(profile);
+      } else {
+        throw fastify.httpErrors.badRequest();
+      };
+    }
+  );
 
-//   fastify.delete(
-//     '/:id',
-//     {
-//       schema: {
-//         params: idParamSchema,
-//       },
-//     },
-//     async function (request, reply): Promise<ProfileEntity> {}
-//   );
+  fastify.delete(
+    '/:id',
+    {
+      schema: {
+        params: idParamSchema,
+      },
+    },
+    async function (request, reply): Promise<ProfileEntity> {
+      const id = request.params.id;
+      const profile = await fastify.db.profiles.findOne({ key: 'id', equals: id });
+      if (profile) {
+        return await fastify.db.profiles.delete(id);
+      } else {
+        throw fastify.httpErrors.badRequest();
+      };
+    }
+  );
 
-//   fastify.patch(
-//     '/:id',
-//     {
-//       schema: {
-//         body: changeProfileBodySchema,
-//         params: idParamSchema,
-//       },
-//     },
-//     async function (request, reply): Promise<ProfileEntity> {}
-//   );
+  fastify.patch(
+    '/:id',
+    {
+      schema: {
+        body: changeProfileBodySchema,
+        params: idParamSchema,
+      },
+    },
+    async function (request, reply): Promise<ProfileEntity> {
+      const id = request.params.id;
+      const newProfile = request.body; 
+      const profile = await fastify.db.profiles.findOne({ key: 'id', equals: id });
+
+      if (profile) {
+        return await fastify.db.profiles.change(id, newProfile);
+      } else {
+        throw fastify.httpErrors.badRequest();
+      };
+    }
+  );
 };
 
 export default plugin;

--- a/src/routes/users/index.ts
+++ b/src/routes/users/index.ts
@@ -65,10 +65,15 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       const id = request.params.id;
       const user = await fastify.db.users.findOne({ key: 'id', equals: id });
       const users = await fastify.db.users.findMany({ key: 'subscribedToUserIds', inArray: id })
+      
       const newArrWithoutDeleteUser = users.map((user) => {
         user.subscribedToUserIds = user.subscribedToUserIds.filter((userId) => userId !== id);
         return user;
       });
+
+      const posts = await fastify.db.posts.findMany({ key: 'userId', equals: id });
+      posts.forEach(async (post) => await fastify.db.posts.delete(post.id));
+
       newArrWithoutDeleteUser.forEach(async (user) => await fastify.db.users.change(user.id, user))
       if (user) {
         return await fastify.db.users.delete(id);
@@ -111,6 +116,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       const deleteSubscribeUserId = request.params.id;
       const id = request.body; 
       const user = await fastify.db.users.findOne({ key: 'id', equals: id.userId });
+
       if (user) {
         const userUnsubscribe = user.subscribedToUserIds.find((userId) => userId === deleteSubscribeUserId);
         if (userUnsubscribe) {

--- a/src/routes/users/index.ts
+++ b/src/routes/users/index.ts
@@ -74,6 +74,9 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       const posts = await fastify.db.posts.findMany({ key: 'userId', equals: id });
       posts.forEach(async (post) => await fastify.db.posts.delete(post.id));
 
+      const profiles = await fastify.db.profiles.findMany({ key: 'userId', equals: id });
+      profiles.forEach(async (profile) => await fastify.db.profiles.delete(profile.id));
+
       newArrWithoutDeleteUser.forEach(async (user) => await fastify.db.users.change(user.id, user))
       if (user) {
         return await fastify.db.users.delete(id);


### PR DESCRIPTION
1. Task: https://github.com/AlreadyBored/nodejs-assignments/blob/main/assignments/graphql-service/assignment.md
2. Deadline: 31.01.2023
3. Score: 83 / 360

Basic Scope
- [x] +72 Task 1: restful endpoints.
- [±] +(11/72) Subtasks 2.1-2.7: get gql queries.
- [ ] +54 Subtasks 2.8-2.11: create gql queries.
- [ ] +54 Subtasks 2.12-2.17: update gql queries.
- [ ] +88 Task 3: solve n+1 graphql problem.
- [ ] +20 Task 4: limit the complexity of the graphql queries.
Forfeits
- [ ] -30% of max task score Commits after deadline (except commits that affect only Readme.md, .gitignore, etc.)
- [ ] -60% of max task score Samples of POST body for gql requests were not provided for those subtasks that were declared to be completed.
- [ ] -100% of max task score Tests have been modified.
- [ ] -20 No separate development branch
- [ ] -20 No Pull Request
- [ ] -10 Pull Request description is incorrect
- [ ] -20 Less than 3 commits in the development branch, not including commits that make changes only to Readme.md or similar files (tsconfig.json, .gitignore, .prettierrc.json, etc.)

Samples of POST body for gql requests
Get gql requests:
2.1. Get users, profiles, posts, memberTypes - 4 operations in one query.
```
query { 
   users { id }
   posts { id }
   pofiles { id }
   memberTypes { id }
}
```